### PR TITLE
File size fix and workaround for hard links

### DIFF
--- a/FilePropertiesDataObject/FileProperties.cs
+++ b/FilePropertiesDataObject/FileProperties.cs
@@ -104,7 +104,7 @@ namespace FilePropertiesDataObject
 
 			CancellationHelper.ThrowIfCancelled();
 
-			bool haveFileReadPermission = false;
+			bool haveFileReadPermission = true;
 			var fileIOPermission = new FileIOPermission(FileIOPermissionAccess.Read, AccessControlActions.View, FullPath);
 			if (fileIOPermission.AllFiles == FileIOPermissionAccess.Read)
 			{

--- a/NtfsReader/System/IO/Filesystem/Ntfs/NtfsReader.cs
+++ b/NtfsReader/System/IO/Filesystem/Ntfs/NtfsReader.cs
@@ -527,6 +527,12 @@ namespace System.IO.Filesystem.Ntfs
 							//node.ParentNodeIndex = ((UInt64)attributeFileName->ParentDirectory.InodeNumberHighPart << 32) + attributeFileName->ParentDirectory.InodeNumberLowPart;
 							node.ParentNodeIndex = attributeFileName->ParentDirectory.InodeNumberLowPart;
 
+							
+							if (node.Size == 0)  //missing file size
+							{
+								node.Size = attributeFileName->DataSize; //set file size if not already set
+							}
+
 							if (attributeFileName->NameType == 1 || node.NameIndex == 0)
 							{ node.NameIndex = GetNameIndex(new string(&attributeFileName->Name, 0, attributeFileName->NameLength)); }
 


### PR DESCRIPTION
Three changes:
Set file size if not already set via $FILE_NAME attribute
disable file permissions check
Work around for hard links